### PR TITLE
automated ibft namespace fix

### DIFF
--- a/helmfile/private-network-ibft-automated/besu-genesis/templates/role-binding.yaml
+++ b/helmfile/private-network-ibft-automated/besu-genesis/templates/role-binding.yaml
@@ -47,5 +47,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: default
+    namespace: {{ .Namespace }}
 


### PR DESCRIPTION
Switched hard coded default namespace for the default sa account to the namespace the helmfile is applying to.

This fixes helmfile applies outside of the default kubernetes namespace.