### PR TITLE
Small readme fix 

### DIFF
--- a/kubectl/private-network-ibft-and-orion/README.md
+++ b/kubectl/private-network-ibft-and-orion/README.md
@@ -46,12 +46,10 @@ docker run -it --volume $PWD/orionSetup/orion4:/opt/orion/data --entrypoint "/bi
 sudo chown -R $USER:$USER ./orionSetup
 ```
 
-Update the secrets/orion-keys-secret.yaml with the private keys. The private keys are put into secrets and the public keys go into a configmap that other nodes use to create the enode address
-Update the configmap/orion-configmap.yaml with the public keys
-**Note:** Please remove the '0x' prefix of the public keys
-
 #### 5. Orion configuration
-Update the orion1.conf to orion4.conf sections in the configmap/orion-configmap.yaml to suit requirements 
+`configmap/configmap.yaml` contains the `orion1.conf` to `orion4.conf` sections. The orion public keys (`orion1PubKey` to `orion4PubKey`) can also be found in here. The orion private keys can be found in `secrets/orion-keys-secret.yaml`.  Update both files with your own generated keypairs
+
+The private keys are put into secrets and the public keys go into a configmap that other nodes use to create the enode address. **Note:** Please remove the '0x' prefix of the public keys
 
 #### 6. Deploy:
 ```bash

--- a/kubectl/private-network-ibft-and-orion/README.md
+++ b/kubectl/private-network-ibft-and-orion/README.md
@@ -47,9 +47,9 @@ sudo chown -R $USER:$USER ./orionSetup
 ```
 
 #### 5. Orion configuration
-`configmap/configmap.yaml` contains the `orion1.conf` to `orion4.conf` sections. The orion public keys (`orion1PubKey` to `orion4PubKey`) can also be found in here. The orion private keys can be found in `secrets/orion-keys-secret.yaml`.  Update both files with your own generated keypairs
+`configmap/configmap.yaml` contains the `orion1.conf` to `orion4.conf` sections. The orion public keys (`orion1PubKey` to `orion4PubKey`) can also be found in here. The orion private keys can be found in `secrets/orion-keys-secret.yaml`.  
 
-The private keys are put into secrets and the public keys go into a configmap that other nodes use to create the enode address. **Note:** Please remove the '0x' prefix of the public keys
+Update both files with your own generated keypairs. The private keys are put into secrets and the public keys go into a configmap that other nodes use to create the enode address. **Note:** Please remove the '0x' prefix of the public keys
 
 #### 6. Deploy:
 ```bash


### PR DESCRIPTION
In the Besu chat channel someone is trying to follow the readme of the `private-network-ibft-and-orion` folder and came across a small mistake that was causing some confusion. See Besu chat for the full question and my response. Tried to make it a little more clear in this PR.

Current setup is still running smooth on my side. Good to see other people are trying this setup as well though! :+1:  