### PR TITLE
increase the cpu limit for the clique network

### DIFF
--- a/kubectl/private-network-clique/deployments/node-deployment.yaml
+++ b/kubectl/private-network-clique/deployments/node-deployment.yaml
@@ -35,7 +35,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 512Mi
           env:
             - name: POD_IP

--- a/kubectl/private-network-clique/deployments/validator1-deployment.yaml
+++ b/kubectl/private-network-clique/deployments/validator1-deployment.yaml
@@ -28,7 +28,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 512Mi
           env:
             - name: POD_IP

--- a/kubectl/private-network-clique/deployments/validator2-deployment.yaml
+++ b/kubectl/private-network-clique/deployments/validator2-deployment.yaml
@@ -35,7 +35,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 512Mi
           env:
             - name: POD_IP

--- a/kubectl/private-network-clique/deployments/validator3-deployment.yaml
+++ b/kubectl/private-network-clique/deployments/validator3-deployment.yaml
@@ -35,7 +35,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 512Mi
           env:
             - name: POD_IP

--- a/kubectl/private-network-clique/deployments/validator4-deployment.yaml
+++ b/kubectl/private-network-clique/deployments/validator4-deployment.yaml
@@ -35,7 +35,7 @@ spec:
               cpu: 100m
               memory: 256Mi
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 512Mi
           env:
             - name: POD_IP


### PR DESCRIPTION
I have been looking into the Grafana chart and I noticed that the 500m cpu limit is always hit when the GC is triggered. This results in pod restarts.

<img width="643" alt="Screenshot 2020-02-14 at 11 43 50" src="https://user-images.githubusercontent.com/1389619/74530321-a8a32280-4f21-11ea-8e16-07177a38bb45.png">

<img width="1347" alt="Screenshot 2020-02-14 at 11 35 33" src="https://user-images.githubusercontent.com/1389619/74530331-accf4000-4f21-11ea-9997-209d73d25e90.png">
