### PR TITLE
websockets failed as rpc and ws has the same ports if ws enabled

### DIFF
--- a/helm/consortium/besu/templates/besu-config-toml-configmap.yaml
+++ b/helm/consortium/besu/templates/besu-config-toml-configmap.yaml
@@ -70,7 +70,7 @@ data:
     # WebSockets API
     rpc-ws-enabled={{ .Values.besuConfig.ws.enabled }}
     rpc-ws-host={{ .Values.besuConfig.ws.host | quote }}
-    rpc-ws-port={{ .Values.besuConfig.rpc.port }}
+    rpc-ws-port={{ .Values.besuConfig.ws.port }}
     rpc-ws-api={{ .Values.besuConfig.ws.api }}
     #rpc-ws-apis=["DEBUG","ETH"]
     rpc-ws-authentication-enabled={{ .Values.besuConfig.ws.authenticationEnabled }}

--- a/helm/consortium/besu/templates/members-besu-config-toml-configmap.yaml
+++ b/helm/consortium/besu/templates/members-besu-config-toml-configmap.yaml
@@ -70,7 +70,7 @@ data:
     # WebSockets API
     rpc-ws-enabled={{ .Values.besuConfig.ws.enabled }}
     rpc-ws-host={{ .Values.besuConfig.ws.host | quote }}
-    rpc-ws-port={{ .Values.besuConfig.rpc.port }}
+    rpc-ws-port={{ .Values.besuConfig.ws.port }}
     rpc-ws-api={{ .Values.besuConfig.ws.api }}
     #rpc-ws-apis=["DEBUG","ETH"]
     rpc-ws-authentication-enabled={{ .Values.besuConfig.ws.authenticationEnabled }}

--- a/helm/ethash/besu/templates/besu-config-toml-configmap.yaml
+++ b/helm/ethash/besu/templates/besu-config-toml-configmap.yaml
@@ -70,7 +70,7 @@ data:
     # WebSockets API
     rpc-ws-enabled={{ .Values.besuConfig.ws.enabled }}
     rpc-ws-host={{ .Values.besuConfig.ws.host | quote }}
-    rpc-ws-port={{ .Values.besuConfig.rpc.port }}
+    rpc-ws-port={{ .Values.besuConfig.ws.port }}
     rpc-ws-api={{ .Values.besuConfig.ws.api }}
     #rpc-ws-apis=["DEBUG","ETH"]
     rpc-ws-authentication-enabled={{ .Values.besuConfig.ws.authenticationEnabled }}

--- a/helm/ibft2-with-privacy/besu/templates/besu-config-toml-configmap.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/besu-config-toml-configmap.yaml
@@ -70,7 +70,7 @@ data:
     # WebSockets API
     rpc-ws-enabled={{ .Values.besuConfig.ws.enabled }}
     rpc-ws-host={{ .Values.besuConfig.ws.host | quote }}
-    rpc-ws-port={{ .Values.besuConfig.rpc.port }}
+    rpc-ws-port={{ .Values.besuConfig.ws.port }}
     rpc-ws-api={{ .Values.besuConfig.ws.api }}
     #rpc-ws-apis=["DEBUG","ETH"]
     rpc-ws-authentication-enabled={{ .Values.besuConfig.ws.authenticationEnabled }}

--- a/helm/ibft2/besu/templates/besu-config-toml-configmap.yaml
+++ b/helm/ibft2/besu/templates/besu-config-toml-configmap.yaml
@@ -70,7 +70,7 @@ data:
     # WebSockets API
     rpc-ws-enabled={{ .Values.besuConfig.ws.enabled }}
     rpc-ws-host={{ .Values.besuConfig.ws.host | quote }}
-    rpc-ws-port={{ .Values.besuConfig.rpc.port }}
+    rpc-ws-port={{ .Values.besuConfig.ws.port }}
     rpc-ws-api={{ .Values.besuConfig.ws.api }}
     #rpc-ws-apis=["DEBUG","ETH"]
     rpc-ws-authentication-enabled={{ .Values.besuConfig.ws.authenticationEnabled }}


### PR DESCRIPTION
if both rpc and ws enabled, in that case besu-node was failed to reach by ingress as rpc and ws has same ports in config.toml