### PR TITLE
Fix the invalid validator2-service.ayml kube spec for besu ibft2.

### DIFF
--- a/kubectl/ibft2/services/validator2-service.yaml
+++ b/kubectl/ibft2/services/validator2-service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: besu-validator2
   labels:
     app: validator2
-namespace: besu
+  namespace: besu
 spec:
   type: ClusterIP
   selector:


### PR DESCRIPTION
Add missing spaces that cause an error.