### PR TITLE
Beus k8s nat manager

### DIFF
--- a/helm/consortium/besu/templates/besu-config-toml-configmap.yaml
+++ b/helm/consortium/besu/templates/besu-config-toml-configmap.yaml
@@ -39,7 +39,7 @@ data:
     # P2P network
     p2p-enabled={{ .Values.besuConfig.p2p.enabled }}
     discovery-enabled={{ .Values.besuConfig.p2p.discovery }}
-    p2p-host={{ .Values.besuConfig.p2p.host | quote }}
+    #p2p-host={{ .Values.besuConfig.p2p.host | quote }}
     p2p-port={{ .Values.besuConfig.p2p.port }}
     max-peers={{ .Values.besuConfig.p2p.maxPeers }}
     {{- end -}}

--- a/helm/consortium/besu/templates/bootnodes-init-configmap.yaml
+++ b/helm/consortium/besu/templates/bootnodes-init-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
   namespace: {{ .Values.namespace.members }}
 data:
   bootnodes-init.sh: |
-    #!/bin/sh
+    #!/bin/bash
     echo "VALIDATOR1_SERVICE_HOST=`getent hosts {{ template "besu.fullname" . }}-validator1.{{ .Values.namespace.consortium }}.svc.cluster.local | awk '{ print $1 }'`" > /bootnodes/service_data.sh
     echo "VALIDATOR2_SERVICE_HOST=`getent hosts {{ template "besu.fullname" . }}-validator2.{{ .Values.namespace.consortium }}.svc.cluster.local | awk '{ print $1 }'`" >> /bootnodes/service_data.sh
     source /bootnodes/service_data.sh && curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 $VALIDATOR1_SERVICE_HOST:8545/liveness

--- a/helm/consortium/besu/templates/members-besu-config-toml-configmap.yaml
+++ b/helm/consortium/besu/templates/members-besu-config-toml-configmap.yaml
@@ -39,7 +39,7 @@ data:
     # P2P network
     p2p-enabled={{ .Values.besuConfig.p2p.enabled }}
     discovery-enabled={{ .Values.besuConfig.p2p.discovery }}
-    p2p-host={{ .Values.besuConfig.p2p.host | quote }}
+    #p2p-host={{ .Values.besuConfig.p2p.host | quote }}
     p2p-port={{ .Values.besuConfig.p2p.port }}
     max-peers={{ .Values.besuConfig.p2p.maxPeers }}
     {{ end }}

--- a/helm/consortium/besu/templates/node-statefulset.yaml
+++ b/helm/consortium/besu/templates/node-statefulset.yaml
@@ -33,9 +33,6 @@ spec:
       initContainers:
         - name: init-bootnode
           image: pegasyseng/k8s-helper:v1.18.4
-          env:
-            - name: VALIDATOR1_SERVICE_HOST
-              value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
           volumeMounts:
             - name: bootnodes-init
               mountPath: /scripts/bootnodes-init.sh
@@ -80,6 +77,10 @@ spec:
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
             - name: VALIDATOR2_SERVICE_HOST
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+            - name: P2P_SERVICE_HOST
+              value: "$({{ template "besu.upperfullname" . }}_NODE_SERVICE_HOST)"
+            - name: NAT_SERVICE_HOST
+              value: "{{ template "besu.fullname" . }}-node"
           volumeMounts:
             - name: genesis-config
               mountPath: /etc/genesis

--- a/helm/consortium/besu/templates/node-statefulset.yaml
+++ b/helm/consortium/besu/templates/node-statefulset.yaml
@@ -77,8 +77,6 @@ spec:
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
             - name: VALIDATOR2_SERVICE_HOST
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
-            - name: P2P_SERVICE_HOST
-              value: "$({{ template "besu.upperfullname" . }}_NODE_SERVICE_HOST)"
             - name: NAT_SERVICE_HOST
               value: "{{ template "besu.fullname" . }}-node"
           volumeMounts:

--- a/helm/consortium/besu/templates/node1privacy-statefulset.yaml
+++ b/helm/consortium/besu/templates/node1privacy-statefulset.yaml
@@ -86,8 +86,6 @@ spec:
             # this allows us to pass in the orion service at runtime and make the script generic
             - name: BESU_ORION_SERVICE_HOST
               value: "$(ORION1_SERVICE_HOST)"
-            - name: P2P_SERVICE_HOST
-              value: "$({{ template "besu.upperfullname" . }}_{{ $nodeNumber|upper}}PRIVACY_SERVICE_HOST)"
             - name: NAT_SERVICE_HOST
               value: "{{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy"
           volumeMounts:

--- a/helm/consortium/besu/templates/node1privacy-statefulset.yaml
+++ b/helm/consortium/besu/templates/node1privacy-statefulset.yaml
@@ -86,6 +86,10 @@ spec:
             # this allows us to pass in the orion service at runtime and make the script generic
             - name: BESU_ORION_SERVICE_HOST
               value: "$(ORION1_SERVICE_HOST)"
+            - name: P2P_SERVICE_HOST
+              value: "$({{ template "besu.upperfullname" . }}_{{ $nodeNumber|upper}}PRIVACY_SERVICE_HOST)"
+            - name: NAT_SERVICE_HOST
+              value: "{{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy"
           volumeMounts:
             - name: orion-pubkey
               mountPath: /configs/orion

--- a/helm/consortium/besu/templates/node2privacy-statefulset.yaml
+++ b/helm/consortium/besu/templates/node2privacy-statefulset.yaml
@@ -86,6 +86,10 @@ spec:
             # this allows us to pass in the orion service at runtime and make the script generic
             - name: BESU_ORION_SERVICE_HOST
               value: "$(ORION2_SERVICE_HOST)"
+            - name: P2P_SERVICE_HOST
+              value: "$({{ template "besu.upperfullname" . }}_{{ $nodeNumber|upper}}PRIVACY_SERVICE_HOST)"
+            - name: NAT_SERVICE_HOST
+              value: "{{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy"
           volumeMounts:
             - name: orion-pubkey
               mountPath: /configs/orion

--- a/helm/consortium/besu/templates/node2privacy-statefulset.yaml
+++ b/helm/consortium/besu/templates/node2privacy-statefulset.yaml
@@ -86,8 +86,6 @@ spec:
             # this allows us to pass in the orion service at runtime and make the script generic
             - name: BESU_ORION_SERVICE_HOST
               value: "$(ORION2_SERVICE_HOST)"
-            - name: P2P_SERVICE_HOST
-              value: "$({{ template "besu.upperfullname" . }}_{{ $nodeNumber|upper}}PRIVACY_SERVICE_HOST)"
             - name: NAT_SERVICE_HOST
               value: "{{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy"
           volumeMounts:

--- a/helm/consortium/besu/templates/nodes-init-configmap.yaml
+++ b/helm/consortium/besu/templates/nodes-init-configmap.yaml
@@ -13,4 +13,4 @@ metadata:
 data:
   nodes-init.sh: |
     #!/bin/bash
-    source /bootnodes/service_data.sh && /opt/besu/bin/besu --config-file=/etc/besu/config.toml --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
+    source /bootnodes/service_data.sh && /opt/besu/bin/besu --config-file=/etc/besu/config.toml --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303 --p2p-host=${P2P_SERVICE_HOST} --Xnat-kube-service-name=${NAT_SERVICE_HOST}

--- a/helm/consortium/besu/templates/nodes-init-configmap.yaml
+++ b/helm/consortium/besu/templates/nodes-init-configmap.yaml
@@ -13,4 +13,4 @@ metadata:
 data:
   nodes-init.sh: |
     #!/bin/bash
-    source /bootnodes/service_data.sh && /opt/besu/bin/besu --config-file=/etc/besu/config.toml --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303 --p2p-host=${P2P_SERVICE_HOST} --Xnat-kube-service-name=${NAT_SERVICE_HOST}
+    source /bootnodes/service_data.sh && /opt/besu/bin/besu --config-file=/etc/besu/config.toml --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303 --Xnat-kube-service-name=${NAT_SERVICE_HOST}

--- a/helm/consortium/besu/templates/validator1-statefulset.yaml
+++ b/helm/consortium/besu/templates/validator1-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
   resources: ["secrets"]
   resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
   verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -140,6 +142,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/consortium/besu/templates/validator1-statefulset.yaml
+++ b/helm/consortium/besu/templates/validator1-statefulset.yaml
@@ -142,7 +142,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
+              --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/consortium/besu/templates/validator2-statefulset.yaml
+++ b/helm/consortium/besu/templates/validator2-statefulset.yaml
@@ -152,7 +152,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
+              --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/consortium/besu/templates/validator2-statefulset.yaml
+++ b/helm/consortium/besu/templates/validator2-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
   resources: ["secrets"]
   resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
   verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -150,6 +152,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/consortium/besu/templates/validator3-statefulset.yaml
+++ b/helm/consortium/besu/templates/validator3-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
   resources: ["secrets"]
   resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
   verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -111,6 +113,8 @@ spec:
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
           - name: VALIDATOR2_SERVICE_HOST
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+          - name: VALIDATOR3_SERVICE_HOST
+            value: "$({{ template "besu.upperfullname" . }}_VALIDATOR3_SERVICE_HOST)"
         volumeMounts:
           - name: key
             mountPath: /secrets
@@ -150,6 +154,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/consortium/besu/templates/validator3-statefulset.yaml
+++ b/helm/consortium/besu/templates/validator3-statefulset.yaml
@@ -154,7 +154,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
+              --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/consortium/besu/templates/validator4-statefulset.yaml
+++ b/helm/consortium/besu/templates/validator4-statefulset.yaml
@@ -154,7 +154,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
+              --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/consortium/besu/templates/validator4-statefulset.yaml
+++ b/helm/consortium/besu/templates/validator4-statefulset.yaml
@@ -13,11 +13,13 @@ metadata:
   name: {{ $validatorNumber }}-key-read-role
   namespace: {{ .Values.namespace.consortium }}
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
-    verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -111,6 +113,8 @@ spec:
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
           - name: VALIDATOR2_SERVICE_HOST
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+          - name: VALIDATOR4_SERVICE_HOST
+            value: "$({{ template "besu.upperfullname" . }}_VALIDATOR4_SERVICE_HOST)"
         volumeMounts:
           - name: key
             mountPath: /secrets
@@ -150,6 +154,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/consortium/besu/values.yaml
+++ b/helm/consortium/besu/values.yaml
@@ -5,7 +5,7 @@ imagePullPolicy: IfNotPresent
 image:
   besu:
     repository: hyperledger/besu
-    tag: latest
+    tag: 1.5.1-SNAPSHOT
   orion:
     repository: pegasyseng/orion
     tag: develop

--- a/helm/ethash/besu/templates/besu-config-toml-configmap.yaml
+++ b/helm/ethash/besu/templates/besu-config-toml-configmap.yaml
@@ -39,7 +39,7 @@ data:
     # P2P network
     p2p-enabled={{ .Values.besuConfig.p2p.enabled }}
     discovery-enabled={{ .Values.besuConfig.p2p.discovery }}
-    p2p-host={{ .Values.besuConfig.p2p.host | quote }}
+    #p2p-host={{ .Values.besuConfig.p2p.host | quote }}
     p2p-port={{ .Values.besuConfig.p2p.port }}
     max-peers={{ .Values.besuConfig.p2p.maxPeers }}
     {{- end -}}

--- a/helm/ethash/besu/templates/bootnode1-statefulset.yaml
+++ b/helm/ethash/besu/templates/bootnode1-statefulset.yaml
@@ -143,7 +143,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${BOOTNODE1_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $bootnodeNumber }} \
+              --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $bootnodeNumber }} \
               --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BOOTNODE2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ethash/besu/templates/bootnode1-statefulset.yaml
+++ b/helm/ethash/besu/templates/bootnode1-statefulset.yaml
@@ -18,7 +18,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ {{ template "besu.fullname" . }}-{{ $bootnodeNumber }}-key ]
     verbs: ["get"]
-
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -141,6 +143,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${BOOTNODE1_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $bootnodeNumber }} \
               --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BOOTNODE2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ethash/besu/templates/bootnode2-statefulset.yaml
+++ b/helm/ethash/besu/templates/bootnode2-statefulset.yaml
@@ -18,6 +18,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ {{ template "besu.fullname" . }}-{{ $bootnodeNumber }}-key ]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 
 ---
 

--- a/helm/ethash/besu/templates/node-statefulset.yaml
+++ b/helm/ethash/besu/templates/node-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-node \
+                --Xnat-kube-service-name={{ template "besu.fullname" . }}-node \
                 --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BOOTNODE2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ethash/besu/templates/node-statefulset.yaml
+++ b/helm/ethash/besu/templates/node-statefulset.yaml
@@ -73,6 +73,8 @@ spec:
               value: "$({{ template "besu.upperfullname" . }}_BOOTNODE1_SERVICE_HOST)"
             - name: BOOTNODE2_SERVICE_HOST
               value: "$({{ template "besu.upperfullname" . }}_BOOTNODE2_SERVICE_HOST)"
+            - name: NODE_SERVICE_HOST
+              value: "$({{ template "besu.upperfullname" . }}_NODE_SERVICE_HOST)"
           volumeMounts:
             - name: genesis-config
               mountPath: /etc/genesis
@@ -108,6 +110,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-node \
                 --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BOOTNODE2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ethash/besu/values.yaml
+++ b/helm/ethash/besu/values.yaml
@@ -4,7 +4,7 @@
 imagePullPolicy: IfNotPresent
 image:
   repository: hyperledger/besu
-  tag: latest
+  tag: 1.5.1-SNAPSHOT
 
 namespace: besu
 

--- a/helm/ibft2-with-privacy/besu/templates/besu-config-toml-configmap.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/besu-config-toml-configmap.yaml
@@ -39,7 +39,7 @@ data:
     # P2P network
     p2p-enabled={{ .Values.besuConfig.p2p.enabled }}
     discovery-enabled={{ .Values.besuConfig.p2p.discovery }}
-    p2p-host={{ .Values.besuConfig.p2p.host | quote }}
+    #p2p-host={{ .Values.besuConfig.p2p.host | quote }}
     p2p-port={{ .Values.besuConfig.p2p.port }}
     max-peers={{ .Values.besuConfig.p2p.maxPeers }}
     {{- end -}}

--- a/helm/ibft2-with-privacy/besu/templates/node-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/node-statefulset.yaml
@@ -74,6 +74,8 @@ spec:
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
             - name: VALIDATOR2_SERVICE_HOST
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+            - name: NODE_SERVICE_HOST
+              value: "$({{ template "besu.upperfullname" . }}_NODE_SERVICE_HOST)"
           volumeMounts:
             - name: genesis-config
               mountPath: /etc/genesis
@@ -109,6 +111,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/node-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/node-statefulset.yaml
@@ -111,7 +111,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-node \
+                --Xnat-kube-service-name={{ template "besu.fullname" . }}-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/node1privacy-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/node1privacy-statefulset.yaml
@@ -120,7 +120,7 @@ spec:
                 --privacy-enabled=true \
                 --privacy-url=http://${ORION1_SERVICE_HOST}:8888 \
                 --privacy-public-key-file=/configs/orion/orion.pub \
-                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy \
+                --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/node1privacy-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/node1privacy-statefulset.yaml
@@ -75,6 +75,8 @@ spec:
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
             - name: VALIDATOR2_SERVICE_HOST
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+            - name: NODE_SERVICE_HOST
+              value: "$({{ template "besu.upperfullname" . }}_{{ $nodeNumber | upper }}PRIVACY_SERVICE_HOST)"
             - name: ORION1_SERVICE_HOST
               value: "$({{ template "besu.upperfullname" . }}_ORION1_SERVICE_HOST)"
           volumeMounts:
@@ -118,6 +120,7 @@ spec:
                 --privacy-enabled=true \
                 --privacy-url=http://${ORION1_SERVICE_HOST}:8888 \
                 --privacy-public-key-file=/configs/orion/orion.pub \
+                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/node2privacy-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/node2privacy-statefulset.yaml
@@ -120,7 +120,7 @@ spec:
                 --privacy-enabled=true \
                 --privacy-url=http://${ORION2_SERVICE_HOST}:8888 \
                 --privacy-public-key-file=/configs/orion/orion.pub \
-                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy \
+                --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/node2privacy-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/node2privacy-statefulset.yaml
@@ -75,6 +75,8 @@ spec:
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
             - name: VALIDATOR2_SERVICE_HOST
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+            - name: NODE_SERVICE_HOST
+              value: "$({{ template "besu.upperfullname" . }}_{{ $nodeNumber | upper }}PRIVACY_SERVICE_HOST)"
             - name: ORION2_SERVICE_HOST
               value: "$({{ template "besu.upperfullname" . }}_ORION2_SERVICE_HOST)"
           volumeMounts:
@@ -118,6 +120,7 @@ spec:
                 --privacy-enabled=true \
                 --privacy-url=http://${ORION2_SERVICE_HOST}:8888 \
                 --privacy-public-key-file=/configs/orion/orion.pub \
+                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $nodeNumber }}privacy \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/validator1-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/validator1-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
     verbs: ["get"]
-
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -140,6 +142,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/validator1-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/validator1-statefulset.yaml
@@ -142,7 +142,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
+              -Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/validator1-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/validator1-statefulset.yaml
@@ -142,7 +142,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              -Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
+              --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/validator2-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/validator2-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
     verbs: ["get"]
-
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -150,6 +152,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/validator2-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/validator2-statefulset.yaml
@@ -152,7 +152,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
+              --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/validator3-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/validator3-statefulset.yaml
@@ -154,7 +154,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
+              --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/validator3-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/validator3-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
     verbs: ["get"]
-
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -111,6 +113,8 @@ spec:
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
           - name: VALIDATOR2_SERVICE_HOST
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+          - name: VALIDATOR3_SERVICE_HOST
+            value: "$({{ template "besu.upperfullname" . }}_VALIDATOR3_SERVICE_HOST)"
         volumeMounts:
           - name: key
             mountPath: /secrets
@@ -150,6 +154,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/validator4-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/validator4-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
     verbs: ["get"]
-
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -111,6 +113,8 @@ spec:
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
           - name: VALIDATOR2_SERVICE_HOST
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+          - name: VALIDATOR4_SERVICE_HOST
+            value: "$({{ template "besu.upperfullname" . }}_VALIDATOR4_SERVICE_HOST)"
         volumeMounts:
           - name: key
             mountPath: /secrets
@@ -150,6 +154,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2-with-privacy/besu/templates/validator4-statefulset.yaml
+++ b/helm/ibft2-with-privacy/besu/templates/validator4-statefulset.yaml
@@ -154,7 +154,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
+              --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2-with-privacy/besu/values.yaml
+++ b/helm/ibft2-with-privacy/besu/values.yaml
@@ -5,7 +5,7 @@ imagePullPolicy: IfNotPresent
 image:
   besu:
     repository: hyperledger/besu
-    tag: latest
+    tag: 1.5.1-SNAPSHOT
   orion:
     repository: pegasyseng/orion
     tag: develop

--- a/helm/ibft2/besu/templates/besu-config-toml-configmap.yaml
+++ b/helm/ibft2/besu/templates/besu-config-toml-configmap.yaml
@@ -39,7 +39,7 @@ data:
     # P2P network
     p2p-enabled={{ .Values.besuConfig.p2p.enabled }}
     discovery-enabled={{ .Values.besuConfig.p2p.discovery }}
-    p2p-host={{ .Values.besuConfig.p2p.host | quote }}
+    #p2p-host={{ .Values.besuConfig.p2p.host | quote }}
     p2p-port={{ .Values.besuConfig.p2p.port }}
     max-peers={{ .Values.besuConfig.p2p.maxPeers }}
     {{ end }}

--- a/helm/ibft2/besu/templates/node-statefulset.yaml
+++ b/helm/ibft2/besu/templates/node-statefulset.yaml
@@ -74,6 +74,8 @@ spec:
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
             - name: VALIDATOR2_SERVICE_HOST
               value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+            - name: NODE_SERVICE_HOST
+              value: "$({{ template "besu.upperfullname" . }}_NODE_SERVICE_HOST)"
           volumeMounts:
             - name: genesis-config
               mountPath: /etc/genesis
@@ -109,6 +111,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ibft2/besu/templates/node-statefulset.yaml
+++ b/helm/ibft2/besu/templates/node-statefulset.yaml
@@ -111,7 +111,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${NODE_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-node \
+                --Xnat-kube-service-name={{ template "besu.fullname" . }}-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/helm/ibft2/besu/templates/validator1-statefulset.yaml
+++ b/helm/ibft2/besu/templates/validator1-statefulset.yaml
@@ -13,11 +13,13 @@ metadata:
   name: {{ $validatorNumber }}-key-read-role
   namespace: {{ .Values.namespace }}
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
-    verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -140,6 +142,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2/besu/templates/validator1-statefulset.yaml
+++ b/helm/ibft2/besu/templates/validator1-statefulset.yaml
@@ -142,7 +142,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
-              --p2p-host=${VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
+              --p2p-host=${VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }} \
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2/besu/templates/validator2-statefulset.yaml
+++ b/helm/ibft2/besu/templates/validator2-statefulset.yaml
@@ -13,11 +13,13 @@ metadata:
   name: {{ $validatorNumber }}-key-read-role
   namespace: {{ .Values.namespace }}
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
-    verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -150,6 +152,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2/besu/templates/validator3-statefulset.yaml
+++ b/helm/ibft2/besu/templates/validator3-statefulset.yaml
@@ -13,11 +13,13 @@ metadata:
   name: {{ $validatorNumber }}-key-read-role
   namespace: {{ .Values.namespace }}
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
-    verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -111,6 +113,8 @@ spec:
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
           - name: VALIDATOR2_SERVICE_HOST
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+          - name: VALIDATOR3_SERVICE_HOST
+            value: "$({{ template "besu.upperfullname" . }}_VALIDATOR3_SERVICE_HOST)"
         volumeMounts:
           - name: key
             mountPath: /secrets
@@ -150,6 +154,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2/besu/templates/validator4-statefulset.yaml
+++ b/helm/ibft2/besu/templates/validator4-statefulset.yaml
@@ -13,10 +13,13 @@ metadata:
   name: {{ $validatorNumber }}-key-read-role
   namespace: {{ .Values.namespace }}
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
-    verbs: ["get"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ {{ template "besu.fullname" . }}-{{ $validatorNumber }}-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 
 ---
 
@@ -111,6 +114,8 @@ spec:
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR1_SERVICE_HOST)"
           - name: VALIDATOR2_SERVICE_HOST
             value: "$({{ template "besu.upperfullname" . }}_VALIDATOR2_SERVICE_HOST)"
+          - name: VALIDATOR4_SERVICE_HOST
+            value: "$({{ template "besu.upperfullname" . }}_VALIDATOR4_SERVICE_HOST)"
         volumeMounts:
           - name: key
             mountPath: /secrets
@@ -150,6 +155,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/key \
               --config-file=/etc/besu/config.toml \
+              --p2p-host=${VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name={{ template "besu.fullname" . }}-{{ $validatorNumber }}\
               --bootnodes=enode://${VALIDATOR1_PUBKEY}@${VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${VALIDATOR2_SERVICE_HOST}:30303
         livenessProbe:
           httpGet:

--- a/helm/ibft2/besu/values.yaml
+++ b/helm/ibft2/besu/values.yaml
@@ -4,7 +4,7 @@
 imagePullPolicy: IfNotPresent
 image:
   repository: hyperledger/besu
-  tag: latest
+  tag: 1.5.1-SNAPSHOT
 
 namespace: besu
 

--- a/helm/ingress/README.md
+++ b/helm/ingress/README.md
@@ -11,11 +11,25 @@ The following will create an nginx ingress controller and rules that route publi
 ```bash
 helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm install grafana-ingress stable/nginx-ingress --namespace monitoring --set controller.replicaCount=2 --set rbac.create=true
-``````
+```
 
-2. Deploy the ingress rules for grafana like so:
+Alternatively to install an ingress for the RPC node service:
+Update the namespace to suit your deployment
+```
+helm install besu-ingress stable/nginx-ingress --namespace besu --set controller.replicaCount=2 --set rbac.create=true
+```
+
+2. Deploy the ingress rules like so:
+For grafana:
+
 ```bash
 kubectl apply -f ingress-rules-grafana.yml
 ```
+For the Besu RPC service :
+
+```bash
+kubectl apply -f ingress-rules-besu.yml
+```
+
 
 

--- a/helmfile/ibft2/charts/besu-node/templates/config-toml-configmap.yaml
+++ b/helmfile/ibft2/charts/besu-node/templates/config-toml-configmap.yaml
@@ -44,7 +44,7 @@ data:
     # P2P network
     p2p-enabled={{ .Values.node.p2p.enabled }}
     discovery-enabled={{ .Values.node.p2p.discovery }}
-    p2p-host={{ .Values.node.p2p.host | quote }}
+    #p2p-host={{ .Values.node.p2p.host | quote }}
     p2p-port={{ .Values.node.p2p.port }}
     max-peers={{ .Values.node.p2p.maxPeers }}
     {{ end }}

--- a/helmfile/ibft2/charts/besu-node/templates/node-statefulset.yaml
+++ b/helmfile/ibft2/charts/besu-node/templates/node-statefulset.yaml
@@ -153,7 +153,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/private.key \
               --config-file=/etc/besu/config.toml \
-              --Xnat-kube-service-name={{ template "besu-node.name" . }} \
+              --Xnat-kube-service-name={{ include "besu-node.fullname" . }} \
 {{- if not .Values.bootnode.enabled }}
               --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BOOTNODE_1_BESU_NODE_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BOOTNODE_2_BESU_NODE_SERVICE_HOST}:30303
 {{ else }}

--- a/helmfile/ibft2/charts/besu-node/templates/node-statefulset.yaml
+++ b/helmfile/ibft2/charts/besu-node/templates/node-statefulset.yaml
@@ -15,7 +15,9 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
-
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -151,6 +153,7 @@ spec:
             exec /opt/besu/bin/besu \
               --node-private-key-file=/secrets/private.key \
               --config-file=/etc/besu/config.toml \
+              --Xnat-kube-service-name={{ template "besu-node.name" . }} \
 {{- if not .Values.bootnode.enabled }}
               --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BOOTNODE_1_BESU_NODE_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BOOTNODE_2_BESU_NODE_SERVICE_HOST}:30303
 {{ else }}

--- a/helmfile/ibft2/charts/besu-node/values.yaml
+++ b/helmfile/ibft2/charts/besu-node/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   repository: hyperledger/besu
-  tag: latest
+  tag: 1.5.1-SNAPSHOT
   pullPolicy: IfNotPresent
 
 bootnode:

--- a/kubectl/clique/configmap/besu-config-toml-configmap.yaml
+++ b/kubectl/clique/configmap/besu-config-toml-configmap.yaml
@@ -34,7 +34,7 @@ data:
     # P2P network
     p2p-enabled=true
     discovery-enabled=true
-    p2p-host="0.0.0.0"
+    #p2p-host="0.0.0.0"
     p2p-port=30303
     max-peers=25
 

--- a/kubectl/clique/statefulsets/node-statefulset.yaml
+++ b/kubectl/clique/statefulsets/node-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: node
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -83,6 +83,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_NODE_SERVICE_HOST} --Xnat-kube-service-name=besu-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/clique/statefulsets/node-statefulset.yaml
+++ b/kubectl/clique/statefulsets/node-statefulset.yaml
@@ -83,7 +83,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_NODE_SERVICE_HOST} --Xnat-kube-service-name=besu-node \
+                --Xnat-kube-service-name=besu-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/clique/statefulsets/validator1-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator1-statefulset.yaml
@@ -123,7 +123,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name=besu-validator1 \
+                --Xnat-kube-service-name=besu-validator1 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/clique/statefulsets/validator1-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator1-statefulset.yaml
@@ -17,6 +17,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ besu-validator1-key ]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -59,7 +62,7 @@ spec:
       serviceAccountName: validator1-sa
       containers:
         - name: validator1
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -120,6 +123,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name=besu-validator1 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/clique/statefulsets/validator2-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator2-statefulset.yaml
@@ -17,6 +17,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ besu-validator2-key ]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -66,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator2
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -127,6 +130,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name=besu-validator2 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/clique/statefulsets/validator2-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator2-statefulset.yaml
@@ -130,7 +130,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name=besu-validator2 \
+                --Xnat-kube-service-name=besu-validator2 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/clique/statefulsets/validator3-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator3-statefulset.yaml
@@ -130,7 +130,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name=besu-validator3 \
+                --Xnat-kube-service-name=besu-validator3 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/clique/statefulsets/validator3-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator3-statefulset.yaml
@@ -17,6 +17,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ besu-validator3-key ]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -66,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator3
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -127,6 +130,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name=besu-validator3 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/clique/statefulsets/validator4-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator4-statefulset.yaml
@@ -130,7 +130,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name=besu-validator4 \
+                --Xnat-kube-service-name=besu-validator4 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/clique/statefulsets/validator4-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator4-statefulset.yaml
@@ -17,6 +17,9 @@ rules:
     resources: ["secrets"]
     resourceNames: [ besu-validator4-key ]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -66,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator4
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -127,6 +130,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name=besu-validator4 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ethash/configmap/besu-config-toml-configmap.yaml
+++ b/kubectl/ethash/configmap/besu-config-toml-configmap.yaml
@@ -34,7 +34,7 @@ data:
     # P2P network
     p2p-enabled=true
     discovery-enabled=true
-    p2p-host="0.0.0.0"
+    #p2p-host="0.0.0.0"
     p2p-port=30303
     max-peers=25
 

--- a/kubectl/ethash/statefulsets/bootnode1-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/bootnode1-statefulset.yaml
@@ -13,11 +13,13 @@ metadata:
   name: bootnode1-key-read-role
   namespace: besu
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ besu-bootnode1-key ]
-    verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ besu-bootnode1-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -59,7 +61,7 @@ spec:
       serviceAccountName: bootnode1-sa
       containers:
         - name: bootnode1
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -123,6 +125,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_BOOTNODE1_SERVICE_HOST} --Xnat-kube-service-name=besu-bootnode1 \
                 --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BESU_BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BESU_BOOTNODE2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ethash/statefulsets/bootnode1-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/bootnode1-statefulset.yaml
@@ -125,7 +125,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_BOOTNODE1_SERVICE_HOST} --Xnat-kube-service-name=besu-bootnode1 \
+                --Xnat-kube-service-name=besu-bootnode1 \
                 --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BESU_BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BESU_BOOTNODE2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ethash/statefulsets/bootnode2-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/bootnode2-statefulset.yaml
@@ -13,10 +13,13 @@ metadata:
   name: bootnode2-key-read-role
   namespace: besu
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ besu-bootnode2-key ]
-    verbs: ["get"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ besu-bootnode2-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -66,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_BOOTNODE1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: bootnode2
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -130,6 +133,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_BOOTNODE2_SERVICE_HOST} --Xnat-kube-service-name=besu-bootnode2 \
                 --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BESU_BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BESU_BOOTNODE2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ethash/statefulsets/bootnode2-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/bootnode2-statefulset.yaml
@@ -133,7 +133,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_BOOTNODE2_SERVICE_HOST} --Xnat-kube-service-name=besu-bootnode2 \
+                --Xnat-kube-service-name=besu-bootnode2 \
                 --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BESU_BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BESU_BOOTNODE2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ethash/statefulsets/minernode-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/minernode-statefulset.yaml
@@ -26,7 +26,7 @@ spec:
             - "curl -X POST --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 --data '{\"jsonrpc\":\"2.0\",\"method\":\"net_peerCount\",\"params\":[],\"id\":1}' $BESU_BOOTNODE1_SERVICE_HOST:8545"
       containers:
         - name: minernode
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ethash/statefulsets/node-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/node-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_BOOTNODE1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: node
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -86,6 +86,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_NODE_SERVICE_HOST} --Xnat-kube-service-name=besu-node \
                 --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BESU_BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BESU_BOOTNODE2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ethash/statefulsets/node-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/node-statefulset.yaml
@@ -86,7 +86,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_NODE_SERVICE_HOST} --Xnat-kube-service-name=besu-node \
+                --Xnat-kube-service-name=besu-node \
                 --bootnodes=enode://${BOOTNODE1_PUBKEY}@${BESU_BOOTNODE1_SERVICE_HOST}:30303,enode://${BOOTNODE2_PUBKEY}@${BESU_BOOTNODE2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/configmap/besu-config-toml-configmap.yaml
+++ b/kubectl/ibft2-with-privacy/configmap/besu-config-toml-configmap.yaml
@@ -34,7 +34,7 @@ data:
     # P2P network
     p2p-enabled=true
     discovery-enabled=true
-    p2p-host="0.0.0.0"
+    #p2p-host="0.0.0.0"
     p2p-port=30303
     max-peers=25
 

--- a/kubectl/ibft2-with-privacy/statefulsets/node-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/node-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: node
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -86,6 +86,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_NODE_SERVICE_HOST} --Xnat-kube-service-name=besu-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/node-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/node-statefulset.yaml
@@ -86,7 +86,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_NODE_SERVICE_HOST} --Xnat-kube-service-name=besu-node \
+                --Xnat-kube-service-name=besu-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/node1privacy-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/node1privacy-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: node1privacy
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -89,6 +89,7 @@ spec:
                 --privacy-enabled=true \
                 --privacy-url=http://${BESU_ORION1_SERVICE_HOST}:8888 \
                 --privacy-public-key-file=/configs/orion/orion.pub \
+                --p2p-host=${BESU_NODE1PRIVACY_SERVICE_HOST} --Xnat-kube-service-name=besu-node1privacy \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/node1privacy-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/node1privacy-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
                 --privacy-enabled=true \
                 --privacy-url=http://${BESU_ORION1_SERVICE_HOST}:8888 \
                 --privacy-public-key-file=/configs/orion/orion.pub \
-                --p2p-host=${BESU_NODE1PRIVACY_SERVICE_HOST} --Xnat-kube-service-name=besu-node1privacy \
+                --Xnat-kube-service-name=besu-node1privacy \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/node2privacy-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/node2privacy-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: node2privacy
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -89,6 +89,7 @@ spec:
                 --privacy-enabled=true \
                 --privacy-url=http://${BESU_ORION2_SERVICE_HOST}:8888 \
                 --privacy-public-key-file=/configs/orion/orion.pub \
+                --p2p-host=${BESU_NODE2PRIVACY_SERVICE_HOST} --Xnat-kube-service-name=besu-node2privacy \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/node2privacy-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/node2privacy-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
                 --privacy-enabled=true \
                 --privacy-url=http://${BESU_ORION2_SERVICE_HOST}:8888 \
                 --privacy-public-key-file=/configs/orion/orion.pub \
-                --p2p-host=${BESU_NODE2PRIVACY_SERVICE_HOST} --Xnat-kube-service-name=besu-node2privacy \
+                --Xnat-kube-service-name=besu-node2privacy \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator1-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator1-statefulset.yaml
@@ -13,11 +13,13 @@ metadata:
   name: validator1-key-read-role
   namespace: besu
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ besu-validator1-key ]
-    verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ besu-validator1-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -59,7 +61,7 @@ spec:
       serviceAccountName: validator1-sa
       containers:
         - name: validator1
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -123,6 +125,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name=besu-validator1 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator1-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator1-statefulset.yaml
@@ -125,7 +125,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name=besu-validator1 \
+                --Xnat-kube-service-name=besu-validator1 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator2-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator2-statefulset.yaml
@@ -133,7 +133,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name=besu-validator2 \
+                --Xnat-kube-service-name=besu-validator2 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator2-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator2-statefulset.yaml
@@ -13,10 +13,13 @@ metadata:
   name: validator2-key-read-role
   namespace: besu
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ besu-validator2-key ]
-    verbs: ["get"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ besu-validator1-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -66,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator2
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -130,6 +133,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name=besu-validator2 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator3-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator3-statefulset.yaml
@@ -13,10 +13,13 @@ metadata:
   name: validator3-key-read-role
   namespace: besu
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ besu-validator3-key ]
-    verbs: ["get"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ besu-validator1-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -66,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator3
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -130,6 +133,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name=besu-validator3 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator3-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator3-statefulset.yaml
@@ -133,7 +133,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name=besu-validator3 \
+                --Xnat-kube-service-name=besu-validator3 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator4-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator4-statefulset.yaml
@@ -133,7 +133,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name=besu-validator4 \
+                --Xnat-kube-service-name=besu-validator4 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator4-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator4-statefulset.yaml
@@ -13,10 +13,13 @@ metadata:
   name: validator4-key-read-role
   namespace: besu
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    resourceNames: [ besu-validator4-key ]
-    verbs: ["get"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [ besu-validator1-key ]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -66,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator4
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -130,6 +133,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name=besu-validator4 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/configmap/besu-config-toml-configmap.yaml
+++ b/kubectl/ibft2/configmap/besu-config-toml-configmap.yaml
@@ -34,7 +34,7 @@ data:
     # P2P network
     p2p-enabled=true
     discovery-enabled=true
-    p2p-host="0.0.0.0"
+    #p2p-host="0.0.0.0"
     p2p-port=30303
     max-peers=25
 

--- a/kubectl/ibft2/statefulsets/node-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/node-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: node
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -86,6 +86,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_NODE_SERVICE_HOST} --Xnat-kube-service-name=besu-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/statefulsets/node-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/node-statefulset.yaml
@@ -86,7 +86,7 @@ spec:
             - |
               exec /opt/besu/bin/besu \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_NODE_SERVICE_HOST} --Xnat-kube-service-name=besu-node \
+                --Xnat-kube-service-name=besu-node \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/statefulsets/validator1-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator1-statefulset.yaml
@@ -125,7 +125,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name=besu-validator1 \
+                --Xnat-kube-service-name=besu-validator1 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/statefulsets/validator1-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator1-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
   resources: ["secrets"]
   resourceNames: [ besu-validator1-key ]
   verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -59,7 +61,7 @@ spec:
       serviceAccountName: validator1-sa
       containers:
         - name: validator1
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -123,6 +125,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR1_SERVICE_HOST} --Xnat-kube-service-name=besu-validator1 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/statefulsets/validator2-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator2-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
   resources: ["secrets"]
   resourceNames: [ besu-validator2-key ]
   verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -66,7 +68,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator2
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -130,6 +132,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name=besu-validator2 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/statefulsets/validator2-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator2-statefulset.yaml
@@ -132,7 +132,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR2_SERVICE_HOST} --Xnat-kube-service-name=besu-validator2 \
+                --Xnat-kube-service-name=besu-validator2 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/statefulsets/validator3-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator3-statefulset.yaml
@@ -132,7 +132,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name=besu-validator3 \
+                --Xnat-kube-service-name=besu-validator3 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/statefulsets/validator3-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator3-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
   resources: ["secrets"]
   resourceNames: [ besu-validator3-key ]
   verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -66,7 +68,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator3
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -130,6 +132,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR3_SERVICE_HOST} --Xnat-kube-service-name=besu-validator3 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/statefulsets/validator4-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator4-statefulset.yaml
@@ -17,7 +17,9 @@ rules:
   resources: ["secrets"]
   resourceNames: [ besu-validator4-key ]
   verbs: ["get"]
-
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
@@ -66,7 +68,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator4
-          image: hyperledger/besu:latest
+          image: hyperledger/besu:1.5.1-SNAPSHOT
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -130,6 +132,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
+                --p2p-host=${BESU_VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name=besu-validator4 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:

--- a/kubectl/ibft2/statefulsets/validator4-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator4-statefulset.yaml
@@ -132,7 +132,7 @@ spec:
               exec /opt/besu/bin/besu \
                 --node-private-key-file=/secrets/key \
                 --config-file=/etc/besu/config.toml \
-                --p2p-host=${BESU_VALIDATOR4_SERVICE_HOST} --Xnat-kube-service-name=besu-validator4 \
+                --Xnat-kube-service-name=besu-validator4 \
                 --bootnodes=enode://${VALIDATOR1_PUBKEY}@${BESU_VALIDATOR1_SERVICE_HOST}:30303,enode://${VALIDATOR2_PUBKEY}@${BESU_VALIDATOR2_SERVICE_HOST}:30303
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Using the Besu k8s Nat manager to bind pods to the service ips to make them more fault tolerant.

# WARNING:
This works only in version 1.5.1-SNAPSHOT or greater of Besu 