### PR TITLE
use the latest tag now that 1.5.0 is out and tagged latest

### DIFF
--- a/helm/consortium/besu/values.yaml
+++ b/helm/consortium/besu/values.yaml
@@ -5,7 +5,7 @@ imagePullPolicy: IfNotPresent
 image:
   besu:
     repository: hyperledger/besu
-    tag: 1.5.1-SNAPSHOT
+    tag: latest
   orion:
     repository: pegasyseng/orion
     tag: develop

--- a/helm/ethash/besu/values.yaml
+++ b/helm/ethash/besu/values.yaml
@@ -4,7 +4,7 @@
 imagePullPolicy: IfNotPresent
 image:
   repository: hyperledger/besu
-  tag: 1.5.1-SNAPSHOT
+  tag: latest
 
 namespace: besu
 

--- a/helm/ibft2-with-privacy/besu/values.yaml
+++ b/helm/ibft2-with-privacy/besu/values.yaml
@@ -5,7 +5,7 @@ imagePullPolicy: IfNotPresent
 image:
   besu:
     repository: hyperledger/besu
-    tag: 1.5.1-SNAPSHOT
+    tag: latest
   orion:
     repository: pegasyseng/orion
     tag: develop

--- a/helm/ibft2/besu/values.yaml
+++ b/helm/ibft2/besu/values.yaml
@@ -4,7 +4,7 @@
 imagePullPolicy: IfNotPresent
 image:
   repository: hyperledger/besu
-  tag: 1.5.1-SNAPSHOT
+  tag: latest
 
 namespace: besu
 

--- a/helmfile/ibft2/charts/besu-node/values.yaml
+++ b/helmfile/ibft2/charts/besu-node/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   repository: hyperledger/besu
-  tag: 1.5.1-SNAPSHOT
+  tag: latest
   pullPolicy: IfNotPresent
 
 bootnode:

--- a/kubectl/clique/statefulsets/node-statefulset.yaml
+++ b/kubectl/clique/statefulsets/node-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: node
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/clique/statefulsets/validator1-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator1-statefulset.yaml
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: validator1-sa
       containers:
         - name: validator1
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/clique/statefulsets/validator2-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator2-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator2
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/clique/statefulsets/validator3-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator3-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator3
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/clique/statefulsets/validator4-statefulset.yaml
+++ b/kubectl/clique/statefulsets/validator4-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator4
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ethash/statefulsets/bootnode1-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/bootnode1-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: bootnode1-sa
       containers:
         - name: bootnode1
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ethash/statefulsets/bootnode2-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/bootnode2-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_BOOTNODE1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: bootnode2
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ethash/statefulsets/minernode-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/minernode-statefulset.yaml
@@ -26,7 +26,7 @@ spec:
             - "curl -X POST --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 --data '{\"jsonrpc\":\"2.0\",\"method\":\"net_peerCount\",\"params\":[],\"id\":1}' $BESU_BOOTNODE1_SERVICE_HOST:8545"
       containers:
         - name: minernode
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ethash/statefulsets/node-statefulset.yaml
+++ b/kubectl/ethash/statefulsets/node-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_BOOTNODE1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: node
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2-with-privacy/statefulsets/node-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/node-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: node
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2-with-privacy/statefulsets/node1privacy-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/node1privacy-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: node1privacy
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2-with-privacy/statefulsets/node2privacy-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/node2privacy-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: node2privacy
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator1-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator1-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: validator1-sa
       containers:
         - name: validator1
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator2-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator2-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator2
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator3-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator3-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator3
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2-with-privacy/statefulsets/validator4-statefulset.yaml
+++ b/kubectl/ibft2-with-privacy/statefulsets/validator4-statefulset.yaml
@@ -69,7 +69,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator4
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2/statefulsets/node-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/node-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: node
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2/statefulsets/validator1-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator1-statefulset.yaml
@@ -61,7 +61,7 @@ spec:
       serviceAccountName: validator1-sa
       containers:
         - name: validator1
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2/statefulsets/validator2-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator2-statefulset.yaml
@@ -68,7 +68,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator2
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2/statefulsets/validator3-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator3-statefulset.yaml
@@ -68,7 +68,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator3
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/kubectl/ibft2/statefulsets/validator4-statefulset.yaml
+++ b/kubectl/ibft2/statefulsets/validator4-statefulset.yaml
@@ -68,7 +68,7 @@ spec:
             - "curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 ${BESU_VALIDATOR1_SERVICE_HOST}:8545/liveness"
       containers:
         - name: validator4
-          image: hyperledger/besu:1.5.1-SNAPSHOT
+          image: hyperledger/besu:latest
           imagePullPolicy: IfNotPresent
           resources:
             requests:


### PR DESCRIPTION
Now that Besu 1.5.0 is released, we can go back to using 'latest'

# Breaking changes:
Besu 1.5.0 introduces some breaking changes to the docker containers & volume mounts i.e to maintain best security practices, the user:group on the Docker container to besu. More information on the [1.5.0 release page](https://github.com/hyperledger/besu/releases/tag/1.5.0)

