### PR TITLE
[GoQuorum] Fix local deploy cannot get correct secret for rpc node & member node

### DIFF
--- a/helm/charts/goquorum-node/templates/node-hooks-pre-install.yaml
+++ b/helm/charts/goquorum-node/templates/node-hooks-pre-install.yaml
@@ -93,7 +93,7 @@ spec:
               kubectl get secret ${key}-keys --namespace {{ .Release.Namespace }} -o json > /dev/null 2>&1
               if [ $? -ne 0 ]; then
                 echo "Creating new $key"
-                kubectl create secret generic ${key}-keys --namespace {{ .Release.Namespace }} --from-file=nodekey=${fpath}/nodekey --from-file=nodekey.pub=${fpath}/nodekey.pub --from-file=enode=${fpath}/nodekey.pub  --from-file=address=${fpath}/address--from-file=accountPrivate.key=${fpath}/accountPrivateKey --from-file=accountPassword=${fpath}/accountPassword --from-file=accountKeystore=${fpath}/accountKeystore --from-file=accountAdddress=${fpath}/accountAddress
+                kubectl create secret generic ${key}-keys --namespace {{ .Release.Namespace }} --from-file=nodekey=${fpath}/nodekey --from-file=nodekey.pub=${fpath}/nodekey.pub --from-file=enode=${fpath}/nodekey.pub --from-file=address=${fpath}/address --from-file=accountPrivateKey=${fpath}/accountPrivateKey --from-file=accountPassword=${fpath}/accountPassword --from-file=accountKeystore=${fpath}/accountKeystore --from-file=accountAddress=${fpath}/accountAddress
               else
                 # if the key exists pull it from secrets so that when you update the enodes configmap, you have the right value
                 echo "Reusing an existing $key"
@@ -178,7 +178,7 @@ spec:
             safeWriteSecret {{ template "goquorum-node.fullname" . }}-tmkeypub $FOLDER_PATH/member0/tessera.pub
             safeWriteSecret {{ template "goquorum-node.fullname" . }}-tmpassword $FOLDER_PATH/member0/passwordFile.txt
 {{- else }}
-            kubectl get secret ${key}-tessera-keys --namespace {{ .Release.Namespace }} -o json > /dev/null 2>&1
+            kubectl get secret {{ template "goquorum-node.fullname" . }}-tessera-keys --namespace {{ .Release.Namespace }} -o json > /dev/null 2>&1
             if [ $? -ne 0 ]; then
               kubectl create secret generic {{ template "goquorum-node.fullname" . }}-tessera-keys --namespace {{ .Release.Namespace }} --from-file=tm.key=$FOLDER_PATH/member0/tessera.key --from-file=tm.pub=$FOLDER_PATH/member0/tessera.pub --from-file=tm.password=$FOLDER_PATH/member0/passwordFile.txt
             fi

--- a/ingress/ingress-rules-monitoring.yml
+++ b/ingress/ingress-rules-monitoring.yml
@@ -12,7 +12,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: besu-ingress-monitoring-routes
+  name: goquorum-ingress-monitoring-routes
   namespace: quorum
   annotations:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"


### PR DESCRIPTION
I got stuck when I tried to install GoQuorum Helm for the RPC node & member node for the local Kubernetes.
The Statefulset showed that the error "cannot find secret {rpc-node-or-member-node}-keys"

-> I found that we need to update the node hook pre-install to fix it!

And I prefer to change the ingress monitoring rule name!